### PR TITLE
Update search URL

### DIFF
--- a/jquery.urduthesaurus.js
+++ b/jquery.urduthesaurus.js
@@ -10,7 +10,7 @@ $.fn.thesaurusize = function (options)
         }
         word = word.trim();
         if (word!='') {
-            window.open("http://urduthesaurus.com/word?q="+word);
+            window.open("http://urduthesaurus.com/search?q="+word);
         }
 	});
 };


### PR DESCRIPTION
Updated the url in jquery to change the 'word' to 'search' as 'word' is stored with diacritical marks so a query for a normalized word doesn't work; but search query, which is normalized, works, though it displays all the relevant results from which the user can click on the first option to go to the right word entry. It is also better for words that don't exist, as well as for words that have similar forms such as a 'word' query for دہقاں results in none, while a 'search' query will give you مشابہ الفاظ: دہقان, etc